### PR TITLE
feat: add synthetic web search tool

### DIFF
--- a/.changeset/web-search-tool.md
+++ b/.changeset/web-search-tool.md
@@ -1,0 +1,9 @@
+---
+"@aliou/pi-synthetic": minor
+---
+
+Add Synthetic web search tool
+
+New tool `synthetic_web_search` allows agents to search the web using Synthetic's zero-data-retention API. Returns search results with titles, URLs, content snippets, and publication dates.
+
+**Note:** Search is a subscription-only feature. The tool will only be registered if the `SYNTHETIC_API_KEY` belongs to an active subscription (verified via the usage endpoint).

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@changesets/cli": "^2.27.11",
     "@mariozechner/pi-coding-agent": "^0.50.1",
     "@mariozechner/pi-tui": "^0.50.1",
+    "@sinclair/typebox": "^0.34.48",
     "@types/node": "^25.0.10",
     "husky": "^9.1.7",
     "typescript": "^5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@mariozechner/pi-tui':
         specifier: ^0.50.1
         version: 0.50.3
+      '@sinclair/typebox':
+        specifier: ^0.34.48
+        version: 0.34.48
       '@types/node':
         specifier: ^25.0.10
         version: 25.1.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { registerSyntheticProvider } from "./providers/index.js";
+import { registerSyntheticWebSearchTool } from "./tools/search.js";
 
-export default function (pi: ExtensionAPI) {
+export default async function (pi: ExtensionAPI) {
   registerSyntheticProvider(pi);
+  await registerSyntheticWebSearchTool(pi);
 }

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,0 +1,243 @@
+import type {
+  AgentToolResult,
+  ExtensionAPI,
+  ExtensionContext,
+  Theme,
+  ToolRenderResultOptions,
+} from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { type Static, Type } from "@sinclair/typebox";
+
+// Types
+interface SyntheticSearchResult {
+  url: string;
+  title: string;
+  text: string;
+  published: string;
+}
+
+interface SyntheticSearchResponse {
+  results: SyntheticSearchResult[];
+}
+
+interface WebSearchDetails {
+  results?: SyntheticSearchResult[];
+  query?: string;
+  error?: string;
+  isError?: boolean;
+}
+
+// Schema
+const SearchParams = Type.Object({
+  query: Type.String({
+    description: "The search query. Be specific for best results.",
+  }),
+});
+
+type SearchParamsType = Static<typeof SearchParams>;
+
+// Check if API key has subscription access by calling usage endpoint
+// Subscription keys have content in the response, usage-based keys return empty array
+async function hasSubscriptionAccess(apiKey: string): Promise<boolean> {
+  try {
+    const response = await fetch("https://api.synthetic.new/v2/usage", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      return false;
+    }
+
+    const data = await response.json();
+    // Subscription keys have content in the response array
+    return Array.isArray(data) && data.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+// Tool Registration
+export async function registerSyntheticWebSearchTool(pi: ExtensionAPI) {
+  // Check for API key
+  const apiKey = process.env.SYNTHETIC_API_KEY;
+  if (!apiKey) {
+    return;
+  }
+
+  // Only register if user has subscription access (search is subscription-only)
+  const hasAccess = await hasSubscriptionAccess(apiKey);
+  if (!hasAccess) {
+    return;
+  }
+
+  pi.registerTool<typeof SearchParams, WebSearchDetails>({
+    name: "synthetic_web_search",
+    label: "Synthetic: Web Search",
+    description:
+      "Search the web using Synthetic's zero-data-retention API. Returns search results with titles, URLs, content snippets, and publication dates. Use for finding documentation, articles, recent information, or any web content. Results are fresh and not cached by Synthetic.",
+    parameters: SearchParams,
+
+    async execute(
+      _toolCallId: string,
+      params: SearchParamsType,
+      onUpdate: (result: AgentToolResult<WebSearchDetails>) => void,
+      _ctx: ExtensionContext,
+      signal?: AbortSignal,
+    ): Promise<AgentToolResult<WebSearchDetails>> {
+      // Check for API key
+      const apiKey = process.env.SYNTHETIC_API_KEY;
+      if (!apiKey) {
+        const error = "SYNTHETIC_API_KEY environment variable is required";
+        return {
+          content: [{ type: "text", text: `Error: ${error}` }],
+          details: { error, isError: true },
+        };
+      }
+
+      // Send progress update
+      onUpdate({
+        content: [{ type: "text", text: "Searching..." }],
+        details: { query: params.query },
+      });
+
+      try {
+        // Make API request
+        const response = await fetch("https://api.synthetic.new/v2/search", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ query: params.query }),
+          signal,
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          const error = `Search API error: ${response.status} ${errorText}`;
+          return {
+            content: [{ type: "text", text: `Error: ${error}` }],
+            details: { error, isError: true },
+          };
+        }
+
+        // Parse response
+        let data: SyntheticSearchResponse;
+        try {
+          data = await response.json();
+        } catch (parseError) {
+          const error =
+            parseError instanceof Error
+              ? `Failed to parse search results: ${parseError.message}`
+              : "Failed to parse search results";
+          return {
+            content: [{ type: "text", text: `Error: ${error}` }],
+            details: { error, isError: true },
+          };
+        }
+
+        // Format results for LLM
+        let content = `Found ${data.results.length} result(s):\n\n`;
+        for (const result of data.results) {
+          content += `## ${result.title}\n`;
+          content += `URL: ${result.url}\n`;
+          content += `Published: ${result.published}\n`;
+          content += `\n${result.text}\n`;
+          content += "\n---\n\n";
+        }
+
+        return {
+          content: [{ type: "text", text: content }],
+          details: {
+            results: data.results,
+            query: params.query,
+          },
+        };
+      } catch (error) {
+        // Handle abort signal
+        if (error instanceof Error && error.name === "AbortError") {
+          return {
+            content: [{ type: "text", text: "Search cancelled" }],
+            details: { query: params.query },
+          };
+        }
+
+        // Handle other errors
+        const message =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        return {
+          content: [{ type: "text", text: `Error: ${message}` }],
+          details: { error: message, isError: true },
+        };
+      }
+    },
+
+    renderCall(args: SearchParamsType, theme: Theme): Text {
+      let text = theme.fg("toolTitle", theme.bold("Synthetic: WebSearch "));
+      text += theme.fg("accent", `"${args.query}"`);
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(
+      result: AgentToolResult<WebSearchDetails>,
+      options: ToolRenderResultOptions,
+      theme: Theme,
+    ): Text {
+      const { expanded, isPartial } = options;
+
+      // Handle partial/loading state
+      if (isPartial) {
+        const text =
+          result.content?.[0]?.type === "text"
+            ? result.content[0].text
+            : "Searching...";
+        return new Text(theme.fg("dim", text), 0, 0);
+      }
+
+      const details = result.details;
+
+      // Handle error state
+      if (details?.isError) {
+        const errorMsg =
+          result.content?.[0]?.type === "text"
+            ? result.content[0].text
+            : "Error occurred";
+        return new Text(theme.fg("error", errorMsg), 0, 0);
+      }
+
+      // Handle success state
+      const results = details?.results || [];
+      let text = theme.fg("success", `✓ Found ${results.length} result(s)`);
+
+      // Collapsed view
+      if (!expanded && results.length > 0) {
+        const first = results[0];
+        text += `\n  ${theme.fg("dim", `${first.title}`)}`;
+        if (results.length > 1) {
+          text += theme.fg("dim", ` (${results.length - 1} more)`);
+        }
+        text += theme.fg("muted", ` [Ctrl+O to expand]`);
+      }
+
+      // Expanded view
+      if (expanded) {
+        for (const r of results) {
+          text += `\n\n${theme.fg("accent", theme.bold(r.title))}`;
+          text += `\n${theme.fg("dim", r.url)}`;
+          if (r.text) {
+            const preview = r.text.slice(0, 200);
+            text += `\n${theme.fg("muted", preview)}`;
+            if (r.text.length > 200) {
+              text += theme.fg("dim", "...");
+            }
+          }
+        }
+      }
+
+      return new Text(text, 0, 0);
+    },
+  });
+}


### PR DESCRIPTION
Add web search tool using Synthetic's zero-data-retention API.

**Features:**
- Search the web with `synthetic_web_search` tool
- Returns results with titles, URLs, content snippets, and publication dates
- TUI rendering with collapsed/expanded views
- Progress updates and abort signal support
- Error handling for API failures

**Requirements:**
- `SYNTHETIC_API_KEY` environment variable
- **Subscription-only**: Tool only registers if the API key has subscription access (verified via usage endpoint)

**API:**
- Endpoint: `POST https://api.synthetic.new/v2/search`
- Docs: https://dev.synthetic.new/docs/synthetic/search

---

**Pi session:** https://buildwithpi.ai/session/#c122f316d69b63e4fcc4c3644aec86ba