### PR TITLE
feat: add /synthetic:quotas command

### DIFF
--- a/.changeset/add-quotas-command.md
+++ b/.changeset/add-quotas-command.md
@@ -1,0 +1,14 @@
+---
+"@aliou/pi-synthetic": minor
+---
+
+Add `/synthetic:quotas` command to display API usage quotas
+
+A new slash command that shows your Synthetic API subscription quotas in a rich terminal UI:
+
+- Visual usage bar with color-coded severity (green/yellow/red based on usage)
+- Aligned columns showing limit, used, and remaining requests
+- ISO8601 renewal timestamp with relative time formatting (e.g., "in 5 hours")
+- Closes on any key press
+
+The command is only registered when `SYNTHETIC_API_KEY` environment variable is set.

--- a/src/commands/quotas.ts
+++ b/src/commands/quotas.ts
@@ -1,0 +1,124 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { Component } from "@mariozechner/pi-tui";
+import { QuotasDisplayComponent } from "../components/quotas-display.js";
+import { QuotasErrorComponent } from "../components/quotas-error.js";
+import { QuotasLoadingComponent } from "../components/quotas-loading.js";
+import type { QuotasResponse } from "../types/quotas.js";
+
+export function registerQuotasCommand(pi: ExtensionAPI): void {
+  pi.registerCommand("synthetic:quotas", {
+    description: "Display Synthetic API usage quotas",
+    handler: async (_args, ctx) => {
+      if (!ctx.hasUI) {
+        const quotas = await fetchQuotas();
+        if (!quotas) {
+          console.error("Failed to fetch quotas");
+          return;
+        }
+        console.log(formatQuotasPlain(quotas));
+        return;
+      }
+
+      await ctx.ui.custom<void>((tui, theme, _kb, done) => {
+        let currentComponent: Component = new QuotasLoadingComponent(theme);
+
+        fetchQuotas()
+          .then((quotas) => {
+            if (!quotas) {
+              currentComponent = new QuotasErrorComponent(
+                theme,
+                "Failed to fetch quotas",
+              );
+            } else {
+              currentComponent = new QuotasDisplayComponent(theme, quotas);
+            }
+            tui.requestRender();
+          })
+          .catch(() => {
+            currentComponent = new QuotasErrorComponent(
+              theme,
+              "Failed to fetch quotas",
+            );
+            tui.requestRender();
+          });
+
+        return {
+          render: (width: number) => currentComponent.render(width),
+          invalidate: () => currentComponent.invalidate(),
+          handleInput: (_data: string) => {
+            done();
+          },
+        };
+      });
+    },
+  });
+}
+
+async function fetchQuotas(): Promise<QuotasResponse | null> {
+  const apiKey = process.env.SYNTHETIC_API_KEY;
+  if (!apiKey) {
+    return null;
+  }
+
+  try {
+    const response = await fetch("https://api.synthetic.new/v2/quotas", {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    return (await response.json()) as QuotasResponse;
+  } catch {
+    return null;
+  }
+}
+
+function formatQuotasPlain(quotas: QuotasResponse): string {
+  const remaining = quotas.subscription.limit - quotas.subscription.requests;
+  const percentUsed = Math.round(
+    (quotas.subscription.requests / quotas.subscription.limit) * 100,
+  );
+
+  return [
+    "Synthetic API Quotas",
+    "",
+    `Usage: ${percentUsed}%`,
+    `Limit: ${quotas.subscription.limit.toLocaleString()} requests`,
+    `Used: ${quotas.subscription.requests.toLocaleString()} requests`,
+    `Remaining: ${remaining.toLocaleString()} requests`,
+    "",
+    `Renews: ${quotas.subscription.renewsAt} (${formatRelativeTime(new Date(quotas.subscription.renewsAt))})`,
+  ].join("\n");
+}
+
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = date.getTime() - now.getTime();
+
+  if (diffMs <= 0) {
+    return "renews soon";
+  }
+
+  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+  const diffMinutes = Math.ceil(diffMs / (1000 * 60));
+  const diffHours = Math.ceil(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMinutes < 60) {
+    return rtf.format(diffMinutes, "minute");
+  } else if (diffHours < 24) {
+    return rtf.format(diffHours, "hour");
+  } else if (diffDays < 30) {
+    return rtf.format(diffDays, "day");
+  } else if (diffDays < 365) {
+    const months = Math.floor(diffDays / 30);
+    return rtf.format(months, "month");
+  } else {
+    const years = Math.floor(diffDays / 365);
+    return rtf.format(years, "year");
+  }
+}

--- a/src/components/quotas-display.ts
+++ b/src/components/quotas-display.ts
@@ -1,0 +1,139 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { DynamicBorder } from "@mariozechner/pi-coding-agent";
+import { type Component, Container, Text } from "@mariozechner/pi-tui";
+import type { QuotasResponse } from "../types/quotas.js";
+
+export class QuotasDisplayComponent implements Component {
+  private container: Container;
+
+  constructor(theme: Theme, quotas: QuotasResponse) {
+    this.container = new Container();
+    const border = new DynamicBorder((s: string) => theme.fg("accent", s));
+
+    this.container.addChild(border);
+    this.container.addChild(
+      new Text(theme.fg("accent", theme.bold(" Synthetic API Quotas ")), 1, 0),
+    );
+    this.container.addChild(new Text("", 0, 0));
+
+    const remaining = quotas.subscription.limit - quotas.subscription.requests;
+    const percentUsed = Math.round(
+      (quotas.subscription.requests / quotas.subscription.limit) * 100,
+    );
+
+    // Usage bar: left side = used (colored by severity), right side = remaining (neutral)
+    const barWidth = 40;
+    const usedWidth = Math.round((percentUsed / 100) * barWidth);
+    const remainingWidth = barWidth - usedWidth;
+
+    let bar: string;
+    if (usedWidth >= barWidth) {
+      bar = theme.fg("error", "█".repeat(barWidth));
+    } else if (percentUsed > 75) {
+      // High usage: used is warning, remaining is dim
+      bar =
+        theme.fg("warning", "█".repeat(usedWidth)) +
+        theme.fg("dim", "█".repeat(remainingWidth));
+    } else {
+      // Normal usage: used is success, remaining is dim
+      bar =
+        theme.fg("success", "█".repeat(usedWidth)) +
+        theme.fg("dim", "█".repeat(remainingWidth));
+    }
+
+    this.container.addChild(new Text(`  ${theme.bold("Usage")}`, 1, 0));
+    this.container.addChild(new Text(`  ${bar} ${percentUsed}%`, 1, 0));
+    this.container.addChild(new Text("", 0, 0));
+
+    // Numbers - aligned columns
+    const limitStr = quotas.subscription.limit.toLocaleString();
+    const usedStr = quotas.subscription.requests.toLocaleString();
+    const remainingStr = remaining.toLocaleString();
+    const maxValueWidth = Math.max(
+      limitStr.length,
+      usedStr.length,
+      remainingStr.length,
+    );
+
+    this.container.addChild(
+      new Text(
+        `  ${theme.fg("muted", "Limit:")}     ${limitStr.padStart(maxValueWidth, " ")} requests`,
+        1,
+        0,
+      ),
+    );
+    this.container.addChild(
+      new Text(
+        `  ${theme.fg("muted", "Used:")}      ${usedStr.padStart(maxValueWidth, " ")} requests`,
+        1,
+        0,
+      ),
+    );
+    this.container.addChild(
+      new Text(
+        `  ${theme.fg("muted", "Remaining:")} ${theme.fg(
+          remaining > 0 ? "success" : "error",
+          remainingStr.padStart(maxValueWidth, " "),
+        )} requests`,
+        1,
+        0,
+      ),
+    );
+    this.container.addChild(new Text("", 0, 0));
+
+    // Renewal date - ISO8601 with relative time
+    const renewsAt = new Date(quotas.subscription.renewsAt);
+    const isoStr = quotas.subscription.renewsAt;
+    const relativeStr = formatRelativeTime(renewsAt);
+
+    this.container.addChild(
+      new Text(
+        `  ${theme.fg("muted", "Renews:")}    ${isoStr} (${relativeStr})`,
+        1,
+        0,
+      ),
+    );
+
+    this.container.addChild(new Text("", 0, 0));
+    this.container.addChild(
+      new Text(theme.fg("dim", "  Press any key to close"), 1, 0),
+    );
+    this.container.addChild(border);
+  }
+
+  render(width: number): string[] {
+    return this.container.render(width);
+  }
+
+  invalidate(): void {
+    this.container.invalidate();
+  }
+}
+
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = date.getTime() - now.getTime();
+
+  if (diffMs <= 0) {
+    return "renews soon";
+  }
+
+  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+  const diffMinutes = Math.ceil(diffMs / (1000 * 60));
+  const diffHours = Math.ceil(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMinutes < 60) {
+    return rtf.format(diffMinutes, "minute");
+  } else if (diffHours < 24) {
+    return rtf.format(diffHours, "hour");
+  } else if (diffDays < 30) {
+    return rtf.format(diffDays, "day");
+  } else if (diffDays < 365) {
+    const months = Math.floor(diffDays / 30);
+    return rtf.format(months, "month");
+  } else {
+    const years = Math.floor(diffDays / 365);
+    return rtf.format(years, "year");
+  }
+}

--- a/src/components/quotas-error.ts
+++ b/src/components/quotas-error.ts
@@ -1,0 +1,32 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { DynamicBorder } from "@mariozechner/pi-coding-agent";
+import { type Component, Container, Text } from "@mariozechner/pi-tui";
+
+export class QuotasErrorComponent implements Component {
+  private container: Container;
+
+  constructor(theme: Theme, message: string) {
+    this.container = new Container();
+    const border = new DynamicBorder((s: string) => theme.fg("accent", s));
+
+    this.container.addChild(border);
+    this.container.addChild(
+      new Text(theme.fg("accent", theme.bold(" Synthetic API Quotas ")), 1, 0),
+    );
+    this.container.addChild(new Text("", 0, 0));
+    this.container.addChild(new Text(theme.fg("error", `  ${message}`), 1, 0));
+    this.container.addChild(new Text("", 0, 0));
+    this.container.addChild(
+      new Text(theme.fg("dim", "  Press any key to close"), 1, 0),
+    );
+    this.container.addChild(border);
+  }
+
+  render(width: number): string[] {
+    return this.container.render(width);
+  }
+
+  invalidate(): void {
+    this.container.invalidate();
+  }
+}

--- a/src/components/quotas-loading.ts
+++ b/src/components/quotas-loading.ts
@@ -1,0 +1,30 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { DynamicBorder } from "@mariozechner/pi-coding-agent";
+import { type Component, Container, Text } from "@mariozechner/pi-tui";
+
+export class QuotasLoadingComponent implements Component {
+  private container: Container;
+
+  constructor(theme: Theme) {
+    this.container = new Container();
+    const border = new DynamicBorder((s: string) => theme.fg("accent", s));
+
+    this.container.addChild(border);
+    this.container.addChild(
+      new Text(theme.fg("accent", theme.bold(" Synthetic API Quotas ")), 1, 0),
+    );
+    this.container.addChild(new Text("", 0, 0));
+    this.container.addChild(
+      new Text(theme.fg("dim", "  Loading quotas..."), 1, 0),
+    );
+    this.container.addChild(border);
+  }
+
+  render(width: number): string[] {
+    return this.container.render(width);
+  }
+
+  invalidate(): void {
+    this.container.invalidate();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { registerQuotasCommand } from "./commands/quotas.js";
 import { registerSyntheticProvider } from "./providers/index.js";
 
 export default function (pi: ExtensionAPI) {
   registerSyntheticProvider(pi);
+
+  // Only register quotas command if API key is available
+  if (process.env.SYNTHETIC_API_KEY) {
+    registerQuotasCommand(pi);
+  }
 }

--- a/src/types/quotas.ts
+++ b/src/types/quotas.ts
@@ -1,0 +1,7 @@
+export interface QuotasResponse {
+  subscription: {
+    limit: number;
+    requests: number;
+    renewsAt: string;
+  };
+}


### PR DESCRIPTION
A new slash command that shows your Synthetic API subscription quotas in a rich terminal UI.

## Features

- Visual usage bar with color-coded severity (green/yellow/red based on usage)
- Aligned columns showing limit, used, and remaining requests
- ISO8601 renewal timestamp with relative time formatting (e.g., "in 5 hours")
- Closes on any key press

## Usage

Type `/synthetic:quotas` in pi to display your current API quotas.

The command is only registered when `SYNTHETIC_API_KEY` environment variable is set.

## API

Uses the Synthetic API endpoint: `GET https://api.synthetic.new/v2/quotas`