### PR TITLE
feat(provider): add Kimi K2.6 model

### DIFF
--- a/.changeset/kind-hornets-approve.md
+++ b/.changeset/kind-hornets-approve.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-synthetic": minor
+---
+
+Add the Synthetic `hf:moonshotai/Kimi-K2.6` model and remove deprecated Kimi K2.5 aliases.

--- a/src/extensions/provider/models.test.ts
+++ b/src/extensions/provider/models.test.ts
@@ -29,6 +29,12 @@ interface Discrepancy {
   api: unknown;
 }
 
+const IGNORED_API_MODEL_IDS = new Set([
+  // Deprecated Kimi K2.5 alias still appears in the raw API, but was removed
+  // from Synthetic's public models page and should not be exposed by pi-synthetic.
+  "hf:nvidia/Kimi-K2.5-NVFP4",
+]);
+
 async function fetchApiModels(): Promise<ApiModel[]> {
   // Making ourselves known
   const response = await fetch("https://api.synthetic.new/openai/v1/models", {
@@ -174,6 +180,7 @@ function compareModels(
 
   // Check for API models not in hardcoded list
   for (const apiModel of apiModels) {
+    if (IGNORED_API_MODEL_IDS.has(apiModel.id)) continue;
     const hardcoded = hardcodedModels.find((m) => m.id === apiModel.id);
     if (!hardcoded) {
       discrepancies.push({

--- a/src/extensions/provider/models.ts
+++ b/src/extensions/provider/models.ts
@@ -187,10 +187,10 @@ export const SYNTHETIC_MODELS: SyntheticModelConfig[] = [
     contextWindow: 262144,
     maxTokens: 65536,
   },
-  // API: hf:moonshotai/Kimi-K2.5 → ctx=262144, out=65536
+  // API: hf:moonshotai/Kimi-K2.6 → ctx=262144, out=65536
   {
-    id: "hf:moonshotai/Kimi-K2.5",
-    name: "moonshotai/Kimi-K2.5",
+    id: "hf:moonshotai/Kimi-K2.6",
+    name: "moonshotai/Kimi-K2.6",
     provider: "synthetic",
     reasoning: true,
     compat: {
@@ -199,29 +199,9 @@ export const SYNTHETIC_MODELS: SyntheticModelConfig[] = [
     },
     input: ["text", "image"],
     cost: {
-      input: 0.45,
-      output: 3.4,
-      cacheRead: 0.45,
-      cacheWrite: 0,
-    },
-    contextWindow: 262144,
-    maxTokens: 65536,
-  },
-  // API: hf:nvidia/Kimi-K2.5-NVFP4 → ctx=262144, out=65536 (NVFP4 quantized)
-  {
-    id: "hf:nvidia/Kimi-K2.5-NVFP4",
-    name: "nvidia/Kimi-K2.5-NVFP4",
-    provider: "synthetic",
-    reasoning: true,
-    compat: {
-      supportsReasoningEffort: true,
-      reasoningEffortMap: SYNTHETIC_REASONING_EFFORT_MAP,
-    },
-    input: ["text", "image"],
-    cost: {
-      input: 0.45,
-      output: 3.4,
-      cacheRead: 0.45,
+      input: 0.95,
+      output: 4,
+      cacheRead: 0.95,
       cacheWrite: 0,
     },
     contextWindow: 262144,


### PR DESCRIPTION
Remove deprecated Kimi K2.5 model aliases from the exposed model list and keep the API parity test ignoring the stale NVFP4 alias while it remains in the raw endpoint.