### PR TITLE
fix(web-search): gate search by subscription

### DIFF
--- a/.changeset/gate-web-search-by-subscription.md
+++ b/.changeset/gate-web-search-by-subscription.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-synthetic": patch
+---
+
+Hide Synthetic web search for accounts without a subscription.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The `provider` field in `extensions/provider/models.ts` is for maintenance only 
 
 ### Web Search Tool
 
-The extension registers `synthetic_web_search` — a zero-data-retention web search tool. The tool is always visible; it fails with a clear message if credentials are missing, the account lacks a subscription, or the configured utility proxy rejects the request.
+The extension registers `synthetic_web_search` — a zero-data-retention web search tool. At session start, it checks the Synthetic quotas API in the background even when another provider is selected. The tool is available only after that check confirms a Synthetic subscription; it remains hidden for pay-as-you-go accounts, missing credentials, and quota API failures.
 
 ### Reasoning Levels
 

--- a/extensions/provider/stream-simple.ts
+++ b/extensions/provider/stream-simple.ts
@@ -13,14 +13,10 @@ import {
   type SimpleStreamOptions,
   type Usage,
 } from "@earendil-works/pi-ai";
-import { parseQuotaHeader, type QuotasResponse } from "../../src/types/quotas";
+import { parseQuotaHeader } from "../../src/types/quotas";
+import { type BillingMode, detectBillingMode } from "../../src/utils/quotas";
 
-/** How a Synthetic request is billed. Determined from the response quota
- *  header: subscription accounts carry one of the subscription quota
- *  windows (`subscription`, `weeklyTokenLimit`, `rollingFiveHourLimit`);
- *  PAYG accounts either omit the header or only carry legacy
- *  `search`/`freeToolCalls` fields. */
-export type BillingMode = "subscription" | "pay-as-you-go";
+export { type BillingMode, detectBillingMode } from "../../src/utils/quotas";
 
 // Synthetic's public docs describe subscription credits and cache token fields,
 // but do not document the cache-read discount. Back-to-back runtime validation
@@ -33,16 +29,6 @@ export type SyntheticStreamSimple = (
   context: Context,
   options?: SimpleStreamOptions,
 ) => AssistantMessageEventStream;
-
-export function detectBillingMode(
-  quotas: QuotasResponse | undefined,
-): BillingMode {
-  return quotas?.subscription ||
-    quotas?.weeklyTokenLimit ||
-    quotas?.rollingFiveHourLimit
-    ? "subscription"
-    : "pay-as-you-go";
-}
 
 export function calculateSyntheticUsageCost(
   model: Pick<Model<Api>, "cost">,

--- a/extensions/web-search/index.test.ts
+++ b/extensions/web-search/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { shouldActivateWebSearch } from "./index";
+
+describe("shouldActivateWebSearch", () => {
+  it("requires both the setting and a confirmed subscription", () => {
+    expect(shouldActivateWebSearch(false, "subscription")).toBe(false);
+    expect(shouldActivateWebSearch(true, "unknown")).toBe(false);
+    expect(shouldActivateWebSearch(true, "pay-as-you-go")).toBe(false);
+    expect(shouldActivateWebSearch(true, "subscription")).toBe(true);
+  });
+});

--- a/extensions/web-search/index.ts
+++ b/extensions/web-search/index.ts
@@ -1,23 +1,37 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
+  resolveSyntheticClientOptions,
+  SyntheticClient,
+} from "../../src/client";
+import {
   configLoader,
   SYNTHETIC_CONFIG_UPDATED_EVENT,
   SYNTHETIC_EXTENSIONS_REGISTER_EVENT,
   SYNTHETIC_EXTENSIONS_REQUEST_EVENT,
   type SyntheticConfigUpdatedPayload,
 } from "../../src/config";
+import { detectBillingMode } from "../../src/utils/quotas";
 import {
   registerSyntheticWebSearchTool,
   SYNTHETIC_WEB_SEARCH_TOOL,
 } from "./tool";
 
-function syncToolActivation(pi: ExtensionAPI, enabled: boolean): void {
+export type WebSearchEntitlement = "unknown" | "subscription" | "pay-as-you-go";
+
+export function shouldActivateWebSearch(
+  enabled: boolean,
+  entitlement: WebSearchEntitlement,
+): boolean {
+  return enabled && entitlement === "subscription";
+}
+
+function syncToolActivation(pi: ExtensionAPI, active: boolean): void {
   const allToolNames = new Set(pi.getAllTools().map((tool) => tool.name));
   const activeTools = new Set(pi.getActiveTools());
 
   if (!allToolNames.has(SYNTHETIC_WEB_SEARCH_TOOL)) return;
 
-  if (enabled) {
+  if (active) {
     activeTools.add(SYNTHETIC_WEB_SEARCH_TOOL);
   } else {
     activeTools.delete(SYNTHETIC_WEB_SEARCH_TOOL);
@@ -29,17 +43,93 @@ function syncToolActivation(pi: ExtensionAPI, enabled: boolean): void {
 export default async function (pi: ExtensionAPI) {
   await configLoader.load();
 
-  let webSearchEnabled = configLoader.getConfig().webSearch;
+  let config = configLoader.getConfig();
+  let entitlement: WebSearchEntitlement = "unknown";
+  let getApiKey: (() => Promise<string | undefined>) | undefined;
+  let quotaCheckId = 0;
+  let quotaCheckController: AbortController | undefined;
 
   registerSyntheticWebSearchTool(pi);
 
-  pi.on("session_start", async () => {
-    syncToolActivation(pi, webSearchEnabled);
+  function syncActivation(): void {
+    syncToolActivation(
+      pi,
+      shouldActivateWebSearch(config.webSearch, entitlement),
+    );
+  }
+
+  function cancelQuotaCheck(): void {
+    quotaCheckId++;
+    quotaCheckController?.abort();
+    quotaCheckController = undefined;
+  }
+
+  function refreshEntitlement(): void {
+    cancelQuotaCheck();
+    const checkId = quotaCheckId;
+    const controller = new AbortController();
+    quotaCheckController = controller;
+
+    void (async () => {
+      try {
+        const options = await resolveSyntheticClientOptions(config, () =>
+          getApiKey ? getApiKey() : Promise.resolve(undefined),
+        );
+        if (!options || checkId !== quotaCheckId) return;
+
+        const result = await new SyntheticClient(options).quotas({
+          signal: controller.signal,
+        });
+        if (checkId !== quotaCheckId || !result.success) return;
+
+        entitlement =
+          detectBillingMode(result.data.quotas) === "subscription"
+            ? "subscription"
+            : "pay-as-you-go";
+        syncActivation();
+      } catch (error) {
+        // Keep the tool inactive until a successful quota response proves
+        // subscription eligibility.
+        void error;
+      }
+    })();
+  }
+
+  pi.on("session_start", async (_event, ctx) => {
+    cancelQuotaCheck();
+    entitlement = "unknown";
+    getApiKey = () => ctx.modelRegistry.getApiKeyForProvider("synthetic");
+    syncActivation();
+    refreshEntitlement();
   });
 
   pi.events.on(SYNTHETIC_CONFIG_UPDATED_EVENT, (data: unknown) => {
-    webSearchEnabled = (data as SyntheticConfigUpdatedPayload).config.webSearch;
-    syncToolActivation(pi, webSearchEnabled);
+    const nextConfig = (data as SyntheticConfigUpdatedPayload).config;
+    const connectionChanged =
+      nextConfig.proxyUrl !== config.proxyUrl ||
+      nextConfig.proxyRequiresAuth !== config.proxyRequiresAuth;
+    const becameEnabled = !config.webSearch && nextConfig.webSearch;
+
+    config = nextConfig;
+
+    if (connectionChanged || (becameEnabled && entitlement === "unknown")) {
+      entitlement = "unknown";
+      syncActivation();
+      refreshEntitlement();
+      return;
+    }
+
+    syncActivation();
+  });
+
+  pi.on("session_before_switch", () => {
+    cancelQuotaCheck();
+    getApiKey = undefined;
+  });
+
+  pi.on("session_shutdown", () => {
+    cancelQuotaCheck();
+    getApiKey = undefined;
   });
 
   pi.events.on(SYNTHETIC_EXTENSIONS_REQUEST_EVENT, () => {

--- a/src/types/quotas.test.ts
+++ b/src/types/quotas.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { parseQuotaHeader } from "./quotas";
+
+describe("parseQuotaHeader", () => {
+  it("parses valid quota payloads", () => {
+    expect(
+      parseQuotaHeader({
+        "x-synthetic-quotas": JSON.stringify({
+          subscription: { limit: 100, requests: 5, renewsAt: "later" },
+        }),
+      }),
+    ).toEqual({
+      subscription: { limit: 100, requests: 5, renewsAt: "later" },
+    });
+  });
+
+  it("rejects payloads that do not match the quota schema", () => {
+    expect(
+      parseQuotaHeader({ "x-synthetic-quotas": JSON.stringify([]) }),
+    ).toBeUndefined();
+    expect(
+      parseQuotaHeader({
+        "x-synthetic-quotas": JSON.stringify({ subscription: {} }),
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/types/quotas.ts
+++ b/src/types/quotas.ts
@@ -1,4 +1,43 @@
+import { type Static, Type } from "typebox";
+import { Value } from "typebox/value";
+
 export type QuotaSource = "header" | "api";
+
+const RequestQuotaSchema = Type.Object({
+  limit: Type.Number(),
+  requests: Type.Number(),
+  renewsAt: Type.String(),
+});
+
+export const QuotasResponseSchema = Type.Object({
+  subscription: Type.Optional(RequestQuotaSchema),
+  search: Type.Optional(
+    Type.Object({
+      hourly: Type.Optional(RequestQuotaSchema),
+    }),
+  ),
+  freeToolCalls: Type.Optional(RequestQuotaSchema),
+  weeklyTokenLimit: Type.Optional(
+    Type.Object({
+      nextRegenAt: Type.String(),
+      percentRemaining: Type.Number(),
+      maxCredits: Type.String(),
+      remainingCredits: Type.String(),
+      nextRegenCredits: Type.String(),
+    }),
+  ),
+  rollingFiveHourLimit: Type.Optional(
+    Type.Object({
+      nextTickAt: Type.String(),
+      tickPercent: Type.Number(),
+      remaining: Type.Number(),
+      max: Type.Number(),
+      limited: Type.Boolean(),
+    }),
+  ),
+});
+
+export type QuotasResponse = Static<typeof QuotasResponseSchema>;
 
 /** Refill-aware projection for a quota window, derived from recent snapshots.
  *
@@ -50,40 +89,6 @@ export type QuotasResult =
   | { success: true; data: { quotas: QuotasResponse } }
   | { success: false; error: { message: string; kind: QuotasErrorKind } };
 
-export interface QuotasResponse {
-  subscription?: {
-    limit: number;
-    requests: number;
-    renewsAt: string;
-  };
-  search?: {
-    hourly?: {
-      limit: number;
-      requests: number;
-      renewsAt: string;
-    };
-  };
-  freeToolCalls?: {
-    limit: number;
-    requests: number;
-    renewsAt: string;
-  };
-  weeklyTokenLimit?: {
-    nextRegenAt: string;
-    percentRemaining: number;
-    maxCredits: string;
-    remainingCredits: string;
-    nextRegenCredits: string;
-  };
-  rollingFiveHourLimit?: {
-    nextTickAt: string;
-    tickPercent: number;
-    remaining: number;
-    max: number;
-    limited: boolean;
-  };
-}
-
 /** Parse the `x-synthetic-quotas` header value into a QuotasResponse.
  *  Returns undefined if the header is missing or invalid. */
 export function parseQuotaHeader(
@@ -96,10 +101,7 @@ export function parseQuotaHeader(
   if (!entry?.[1]) return undefined;
   try {
     const parsed = JSON.parse(entry[1]);
-    // Basic structural check: must be a non-null object
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
-      return undefined;
-    return parsed as QuotasResponse;
+    return Value.Check(QuotasResponseSchema, parsed) ? parsed : undefined;
   } catch {
     return undefined;
   }

--- a/src/utils/quotas.test.ts
+++ b/src/utils/quotas.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { QuotasResponse } from "../types/quotas";
+import { detectBillingMode } from "./quotas";
+
+describe("detectBillingMode", () => {
+  it.each([
+    { subscription: { limit: 1, requests: 0, renewsAt: "later" } },
+    {
+      weeklyTokenLimit: {
+        nextRegenAt: "later",
+        percentRemaining: 50,
+        maxCredits: "$10",
+        remainingCredits: "$5",
+        nextRegenCredits: "$1",
+      },
+    },
+    {
+      rollingFiveHourLimit: {
+        nextTickAt: "later",
+        tickPercent: 50,
+        remaining: 5,
+        max: 10,
+        limited: false,
+      },
+    },
+  ])("recognizes subscription quota windows", (quotas) => {
+    expect(detectBillingMode(quotas)).toBe("subscription");
+  });
+
+  it("recognizes empty and missing quotas as pay-as-you-go", () => {
+    expect(detectBillingMode({})).toBe("pay-as-you-go");
+    expect(detectBillingMode(undefined)).toBe("pay-as-you-go");
+  });
+
+  it("rejects malformed subscription quota windows", () => {
+    expect(detectBillingMode({ subscription: {} } as QuotasResponse)).toBe(
+      "pay-as-you-go",
+    );
+    expect(
+      detectBillingMode({
+        weeklyTokenLimit: true,
+      } as unknown as QuotasResponse),
+    ).toBe("pay-as-you-go");
+  });
+});

--- a/src/utils/quotas.ts
+++ b/src/utils/quotas.ts
@@ -1,3 +1,45 @@
+import { Type } from "typebox";
+import { Value } from "typebox/value";
+import type { QuotasResponse } from "../types/quotas";
+
+export type BillingMode = "subscription" | "pay-as-you-go";
+
+const SubscriptionQuotaSchema = Type.Object({
+  limit: Type.Number(),
+  requests: Type.Number(),
+  renewsAt: Type.String(),
+});
+
+const WeeklyTokenLimitSchema = Type.Object({
+  nextRegenAt: Type.String(),
+  percentRemaining: Type.Number(),
+  maxCredits: Type.String(),
+  remainingCredits: Type.String(),
+  nextRegenCredits: Type.String(),
+});
+
+const RollingFiveHourLimitSchema = Type.Object({
+  nextTickAt: Type.String(),
+  tickPercent: Type.Number(),
+  remaining: Type.Number(),
+  max: Type.Number(),
+  limited: Type.Boolean(),
+});
+
+/**
+ * Synthetic subscription accounts expose at least one subscription quota
+ * window. PAYG accounts return an empty quota object or legacy tool windows.
+ */
+export function detectBillingMode(
+  quotas: QuotasResponse | undefined,
+): BillingMode {
+  return Value.Check(SubscriptionQuotaSchema, quotas?.subscription) ||
+    Value.Check(WeeklyTokenLimitSchema, quotas?.weeklyTokenLimit) ||
+    Value.Check(RollingFiveHourLimitSchema, quotas?.rollingFiveHourLimit)
+    ? "subscription"
+    : "pay-as-you-go";
+}
+
 export function formatResetTime(renewsAt: string): string {
   const date = new Date(renewsAt);
   const now = new Date();


### PR DESCRIPTION
## Summary

- PR opened by Pi.
- Hide `synthetic_web_search` until a background `/v2/quotas` request confirms a Synthetic subscription, regardless of the selected model provider.
- Validate quota headers and subscription windows with TypeBox.

Closes #81