### PR TITLE
feat: expose native max thinking level on GLM-5.2

### DIFF
--- a/.changeset/glm-52-max-thinking.md
+++ b/.changeset/glm-52-max-thinking.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-synthetic": minor
+---
+
+Expose Pi's native `max` thinking level on `hf:zai-org/GLM-5.2` (and its `syn:large:text` alias). GLM-5.2 now maps `max -> "max"` (literal, accepted by Synthetic's OpenAI shim) instead of the previous `xhigh -> "medium"` fallthrough. `xhigh` is hidden; the two effective tiers remain off / high / max. Bump pi peer/dev deps to 0.80.7.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ src/
   },
   contextWindow: 202752,
   maxTokens: 65536,
-  thinkingLevelMap?: { off?: "none" | null; minimal?: null; low?: null; medium?: "medium" | null; high?: null; xhigh?: null; ... },
+  thinkingLevelMap?: { off?: "none" | null; minimal?: null; low?: null; medium?: "medium" | null; high?: null; xhigh?: null; max?: "max" | null; ... },
   compat?: {        // Optional provider-specific compatibility flags
     supportsDeveloperRole?: boolean,
     supportsReasoningEffort?: boolean,

--- a/README.md
+++ b/README.md
@@ -68,14 +68,13 @@ The extension registers `synthetic_web_search` — a zero-data-retention web sea
 
 ### Reasoning Levels
 
-For Synthetic models that support reasoning, Synthetic currently accepts only `low`, `medium`, and `high` reasoning effort values.
+Synthetic reasoning models are mostly binary on/off (a single `medium` toggle in Pi's UI). The exception is `hf:zai-org/GLM-5.2`, which exposes two tiers plus off:
 
-This extension clamps Pi reasoning levels to Synthetic's supported set:
-- `minimal` -> `low`
-- `low` -> `low`
-- `medium` -> `medium`
-- `high` -> `high`
-- `xhigh` -> `high`
+- off → `none` (disable reasoning)
+- high → `high` (GLM High tier, lower)
+- max → `max` (GLM Max tier, highest — native `max` thinking level, accepted by Synthetic's OpenAI shim)
+
+Other Pi levels (`minimal`, `low`, `medium`, `xhigh`) are hidden for GLM-5.2. Aliases such as `syn:large:text` inherit this map from their target at build time. The `max` level is opt-in and was added in Pi 0.80.6.
 
 ### Quotas Command
 

--- a/extensions/provider/models.ts
+++ b/extensions/provider/models.ts
@@ -12,14 +12,11 @@ export type SyntheticModel = ProviderModelConfig;
 
 export const SYNTHETIC_MODELS: SyntheticModel[] = [
   // API: syn:large:text → ctx=524288, out=65536
-  // Reasoning: GLM-5.2 has only two effective levels — `max` (default, highest) and `high`
+  // Reasoning: GLM-5.2 has two effective tiers — `max` (default, highest) and `high`
   // (lower). Per the GLM-5.2 chat template: unset -> max; "high" -> high; every other value
-  // ("low", "medium", ...) falls through to max. So `max > high`.
-  // The Synthetic OpenAI shim validates `reasoning_effort` to the OpenAI enum and rejects
-  // literal `max` (and `xhigh` errors). To expose both tiers through Pi we map:
-  //   off    -> "none"      (disable thinking)
-  //   high   -> "high"       (High, lower)
-  //   xhigh  -> "medium"     (falls through to Max, highest)
+  // falls through to max. So `max > high`.
+  // Verified against Synthetic's OpenAI shim: `reasoning_effort: "max"` and `"none"` are
+  // accepted. Map the two tiers plus off; hide unsupported intermediate tiers.
   {
     id: "syn:large:text",
     name: "syn:large:text",
@@ -30,7 +27,8 @@ export const SYNTHETIC_MODELS: SyntheticModel[] = [
       low: null,
       medium: null,
       high: "high",
-      xhigh: "medium",
+      xhigh: null,
+      max: "max",
     },
     compat: {
       supportsReasoningEffort: true,
@@ -149,7 +147,8 @@ export const SYNTHETIC_MODELS: SyntheticModel[] = [
       low: null,
       medium: null,
       high: "high",
-      xhigh: "medium",
+      xhigh: null,
+      max: "max",
     },
     compat: {
       supportsReasoningEffort: true,


### PR DESCRIPTION
> [!IMPORTANT]
> This PR was opened by `Pi (glm-5.2)` (an AI coding agent).

## Summary

Exposes Pi 0.80.6's native `max` thinking level on `hf:zai-org/GLM-5.2` (and its `syn:large:text` alias, which inherits the map at build time).

## Context

Pi 0.80.6 introduced an opt-in `max` thinking level above `xhigh`, natively supported on GPT-5.6 and adaptive Claude models. The changelog also documents a blessed "hole" pattern: a model can expose `high` and `max` without exposing `xhigh`. This PR wires that up for the one Synthetic model that has a real `max` tier.

## Changes

- **`extensions/provider/models.ts`** — GLM-5.2 `thinkingLevelMap`: `max -> "max"` (literal), replacing the previous `xhigh -> "medium"` fallthrough workaround. `xhigh` is now hidden (`null`). The two effective tiers remain: off / high / max.
- **`package.json`** + **`pnpm-lock.yaml`** — bumped `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` devDeps `0.80.6 -> 0.80.7` (`max` level landed in 0.80.6; peer ranges stay `*`).
- **`AGENTS.md`** — added `max?: "max" | null` to the `thinkingLevelMap` shape example.
- **`README.md`** — rewrote the stale "Reasoning Levels" section (it described a generic clamp that per-model maps had already superseded) to document GLM-5.2's off / high / max tiers.
- **`.changeset/glm-52-max-thinking.md`** — minor changeset.

## Verification

Probed Synthetic's OpenAI shim directly through the authenticated proxy (`http://ai.tetra-albacore.ts.net/v1/connectors/synthetic/openai/v1`) to confirm the shim accepts literal `reasoning_effort: "max"` for GLM-5.2 — the previous code's comment (which claimed the shim rejected `max`) was outdated.

| effort | reasoning tokens | accepted |
|---|---|---|
| `none` | 0 | yes (disables reasoning) |
| `high` | 124 | yes |
| `max` | 132 | yes (Max tier) |

Pre-commit hooks ran typecheck, lint, format, and full test suite — all green (122 tests, 7 files).

## Other-models investigation

Checked whether any other Synthetic reasoning model exposes a clean `max` tier (3 samples each via the proxy):

| Model | `max` accepted? | Verdict |
|---|---|---|
| `hf:zai-org/GLM-4.7-Flash` | no (vLLM rejects: low/medium/high only) | unchanged |
| `hf:openai/gpt-oss-120b` | no (Harmony rejects: high/medium/low only) | unchanged |
| `hf:moonshotai/Kimi-K2.7-Code` | yes, but non-monotonic (med 523 > high 388 > max 286) | not a real max tier — unchanged |
| `hf:Qwen/Qwen3.6-27B` | yes, but noisy (max 2484 ≈ med 2310 ≈ high 1958) | not a distinct higher tier — unchanged |
| `hf:MiniMaxAI/MiniMax-M3` | yes, but reasoning broken across all efforts (37-127c, `reasoning_tokens: 0`) | unchanged |
| `hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` | no (vLLM rejects) | unchanged |

**GLM-5.2 is the only Synthetic model with a legitimate `max` tier.** No other models warranted a mapping change.

## Behavior change

Selecting `xhigh` on GLM-5.2 no longer works; users select `max` instead. Aliases (`syn:large:text -> GLM-5.2`) inherit the new map automatically.