### PR TITLE
feat(models): expose xhigh thinking level for Qwen3.8-27B

### DIFF
--- a/.changeset/qwen38-xhigh.md
+++ b/.changeset/qwen38-xhigh.md
@@ -1,0 +1,7 @@
+---
+"@aliou/pi-synthetic": patch
+---
+
+### Qwen3.8-27B: expose xhigh thinking level
+
+Upstream metadata (`GET /v1/models`) declares `reasoning_parameters.efforts: ["low", "medium", "xhigh"]` for `hf:Qwen/Qwen3.8-27B`. Live probes confirm `xhigh` produces the deepest reasoning, `low` returns no reasoning content even on hard prompts, and `high`/`max` are accepted but not model-native. `thinkingLevelMap` now exposes off / medium / xhigh.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Synthetic reasoning models are mostly binary on/off (a single `medium` toggle in
 
 Other Pi levels (`minimal`, `low`, `medium`, `xhigh`) are hidden for GLM-5.2. The `max` level is opt-in and was added in Pi 0.80.6.
 
+`hf:Qwen/Qwen3.8-27B` exposes off / medium / xhigh. Upstream metadata declares `["low", "medium", "xhigh"]`, but live probes show `low` returns no reasoning content (even on hard prompts), so it stays hidden; `high`/`max` are not model-native and fall through to the default.
+
 ### Quotas Command
 
 Check your API usage:

--- a/README.md
+++ b/README.md
@@ -92,8 +92,6 @@ Synthetic reasoning models are mostly binary on/off (a single `medium` toggle in
 
 Other Pi levels (`minimal`, `low`, `medium`, `xhigh`) are hidden for GLM-5.2. The `max` level is opt-in and was added in Pi 0.80.6.
 
-`hf:Qwen/Qwen3.8-27B` exposes off / medium / xhigh. Upstream metadata declares `["low", "medium", "xhigh"]`, but live probes show `low` returns no reasoning content (even on hard prompts), so it stays hidden; `high`/`max` are not model-native and fall through to the default.
-
 ### Quotas Command
 
 Check your API usage:

--- a/extensions/provider/models.ts
+++ b/extensions/provider/models.ts
@@ -277,7 +277,8 @@ export const SYNTHETIC_MODELS: SyntheticModel[] = [
       low: null,
       medium: "medium",
       high: null,
-      xhigh: null,
+      xhigh: "xhigh",
+      max: null,
     },
     compat: {
       supportsReasoningEffort: true,


### PR DESCRIPTION
## Background

Qwen3.8-27B previously only exposed medium. Per discussion with the repo bot's empirical check, upstream metadata `GET /v1/models` declares `reasoning_parameters.efforts: ["low", "medium", "xhigh"]` for this model, so `xhigh` — not `high`/`max` — is the correct top tier to expose.

## Live probe evidence (hf:Qwen/Qwen3.8-27B, 2026-08-24/25)

| reasoning_effort | HTTP | reasoning_content |
|---|---|---|
| low | 200 | empty, even on a hard multi-step math prompt (declared, but effectively no reasoning) |
| medium | 200 | present |
| high | 200 | present, but not model-native (falls through to default) |
| xhigh | 200 | present, deepest (2512 chars on hard prompt; declared model default) |
| max | 200 | present, but not model-native (falls through to default) |

## Changes

- thinkingLevelMap: expose off / medium / xhigh; keep low / high / max hidden
- README Reasoning Levels section updated
- patch changeset

Verified: tsc --noEmit, 163 tests pass.